### PR TITLE
Added support for Winget packages

### DIFF
--- a/src/Cupboard.Tests/Unit/Resources/WingetProviderTests.cs
+++ b/src/Cupboard.Tests/Unit/Resources/WingetProviderTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cupboard.Testing;
+using Shouldly;
+
+namespace Cupboard.Tests.Unit.Resources
+{
+    public sealed class WingetProviderTests
+    {
+        public sealed class Manifests
+        {
+            public sealed class Install : Manifest
+            {
+                public override void Execute(ManifestContext context)
+                {
+                    context.Resource<WingetPackage>("GitHub CLI")
+                        .Package("GitHub.cli")
+                        .Ensure(PackageState.Installed);
+                }
+            }
+
+            public sealed class Uninstall : Manifest
+            {
+                public override void Execute(ManifestContext context)
+                {
+                    context.Resource<WingetPackage>("GitHub CLI")
+                        .Package("GitHub.cli")
+                        .Ensure(PackageState.Uninstalled);
+                }
+            }
+        }
+
+        public sealed class EnsureInstalled
+        {
+            [WindowsFact]
+            public void Should_Install_Package_If_Missing()
+            {
+                // Given
+                var fixture = new CupboardFixture();
+                fixture.Security.IsAdmin = true;
+                fixture.Configure(ctx => ctx.UseManifest<Manifests.Install>());
+
+                fixture.Process.Register("winget", "list --source winget --id GitHub.cli",
+                    new ProcessRunnerResult(int.MinValue, "No installed package found matching input criteria."),
+                    new ProcessRunnerResult(0, "GitHub CLI GitHub.cli 1.12.1"));
+
+                fixture.Process.Register("winget", "install -e --id GitHub.cli --force",
+                    new ProcessRunnerResult(0, "Lol installed GitHub.cli"));
+
+                // When
+                var result = fixture.Run("-y");
+
+                // Then
+                result.Report.GetState<WingetPackage>("GitHub CLI").ShouldBe(ResourceState.Changed);
+                fixture.Logger.WasLogged("Installing Winget package [yellow]GitHub.cli[/]");
+                fixture.Logger.WasLogged("The Winget package [yellow]GitHub.cli[/] was installed");
+            }
+
+            [WindowsFact]
+            public void Should_Not_Install_Package_If_Present_lol()
+            {
+                // Given
+                var fixture = new CupboardFixture();
+                fixture.Security.IsAdmin = true;
+                fixture.Configure(ctx => ctx.UseManifest<Manifests.Install>());
+
+                fixture.Process.Register("winget", "list --source winget --id GitHub.cli",
+                    new ProcessRunnerResult(0, "GitHub CLI GitHub.cli 1.12.1"));
+
+                // When
+                var result = fixture.Run("-y");
+
+                // Then
+                result.Report.GetState<WingetPackage>("GitHub CLI").ShouldBe(ResourceState.Unchanged);
+                fixture.Logger.WasLogged("The Winget package [yellow]GitHub.cli[/] is already installed");
+            }
+        }
+
+        public sealed class EnsureUninstalled
+        {
+            [WindowsFact]
+            public void Should_Uninstall_Package_If_Present()
+            {
+                // Given
+                var fixture = new CupboardFixture();
+                fixture.Security.IsAdmin = true;
+                fixture.Configure(ctx => ctx.UseManifest<Manifests.Uninstall>());
+
+                fixture.Process.Register("winget", "list --source winget --id GitHub.cli",
+                    new ProcessRunnerResult(0, "GitHub CLI GitHub.cli 1.12.1"));
+
+                fixture.Process.Register("winget", "uninstall -e --id GitHub.cli", new ProcessRunnerResult(0));
+
+                // When
+                var result = fixture.Run("-y");
+
+                // Then
+                result.Report.GetState<WingetPackage>("GitHub CLI").ShouldBe(ResourceState.Changed);
+                fixture.Logger.WasLogged("Uninstalling Winget package GitHub.cli...");
+                fixture.Logger.WasLogged("The Winget package [yellow]GitHub.cli[/] was uninstalled");
+            }
+
+            [WindowsFact]
+            public void Should_Not_Uninstall_Package_If_Absent()
+            {
+                // Given
+                var fixture = new CupboardFixture();
+                fixture.Security.IsAdmin = true;
+                fixture.Configure(ctx => ctx.UseManifest<Manifests.Uninstall>());
+
+                fixture.Process.Register("winget", "list --source winget --id GitHub.cli",
+                    new ProcessRunnerResult(int.MinValue, "No installed package found matching input criteria."));
+
+                // When
+                var result = fixture.Run("-y");
+
+                // Then
+                result.Report.GetState<WingetPackage>("GitHub CLI").ShouldBe(ResourceState.Unchanged);
+                fixture.Logger.WasLogged("The Winget package [yellow]GitHub.cli[/] is already uninstalled");
+            }
+        }
+    }
+}

--- a/src/Cupboard.Tests/Unit/Resources/WingetProviderTests.cs
+++ b/src/Cupboard.Tests/Unit/Resources/WingetProviderTests.cs
@@ -90,7 +90,8 @@ namespace Cupboard.Tests.Unit.Resources
                 fixture.Configure(ctx => ctx.UseManifest<Manifests.Uninstall>());
 
                 fixture.Process.Register("winget", "list --source winget --id GitHub.cli",
-                    new ProcessRunnerResult(0, "GitHub CLI GitHub.cli 1.12.1"));
+                    new ProcessRunnerResult(0, "GitHub CLI GitHub.cli 1.12.1"),
+                    new ProcessRunnerResult(int.MinValue, "No installed package found matching input criteria."));
 
                 fixture.Process.Register("winget", "uninstall -e --id GitHub.cli", new ProcessRunnerResult(0));
 

--- a/src/Cupboard/Resources/Windows/Winget/WingetPackage.cs
+++ b/src/Cupboard/Resources/Windows/Winget/WingetPackage.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Cupboard
+{
+    public sealed class WingetPackage : Resource
+    {
+        public string Package { get; set; }
+        public PackageState Ensure { get; set; }
+
+        public WingetPackage(string name)
+            : base(name)
+        {
+            Package = name ?? throw new ArgumentNullException(nameof(name));
+        }
+    }
+}

--- a/src/Cupboard/Resources/Windows/Winget/WingetPackageExtensions.cs
+++ b/src/Cupboard/Resources/Windows/Winget/WingetPackageExtensions.cs
@@ -1,0 +1,15 @@
+namespace Cupboard
+{
+    public static class WingetPackageExtensions
+    {
+        public static IResourceBuilder<WingetPackage> Ensure(this IResourceBuilder<WingetPackage> builder, PackageState state)
+        {
+            return builder.Configure(pkg => pkg.Ensure = state);
+        }
+
+        public static IResourceBuilder<WingetPackage> Package(this IResourceBuilder<WingetPackage> builder, string package)
+        {
+            return builder.Configure(pkg => pkg.Package = package);
+        }
+    }
+}

--- a/src/Cupboard/Resources/Windows/Winget/WingetPackageProvider.cs
+++ b/src/Cupboard/Resources/Windows/Winget/WingetPackageProvider.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Cupboard
+{
+    public sealed class WingetPackageProvider : AsyncWindowsResourceProvider<WingetPackage>
+    {
+        private readonly IProcessRunner _runner;
+        private readonly IEnvironmentRefresher _refresher;
+        private readonly ICupboardLogger _logger;
+        private string? _cachedOutput;
+        private bool _dirty;
+
+        private enum WingetPackageState
+        {
+            Exists,
+            Missing,
+            Error,
+        }
+
+        public WingetPackageProvider(IProcessRunner runner, IEnvironmentRefresher refresher, ICupboardLogger logger)
+        {
+            _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+            _refresher = refresher ?? throw new ArgumentNullException(nameof(refresher));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _dirty = true;
+        }
+
+        public override WingetPackage Create(string name)
+        {
+            return new WingetPackage(name)
+            {
+                Package = name,
+            };
+        }
+
+        public override bool RequireAdministrator(FactCollection facts)
+        {
+            return true;
+        }
+
+        public override async Task<ResourceState> RunAsync(IExecutionContext context, WingetPackage resource)
+        {
+            var state = await IsPackageInstalled(resource.Package).ConfigureAwait(false);
+            if (state == WingetPackageState.Error)
+            {
+                return ResourceState.Error;
+            }
+
+            if (resource.Ensure == PackageState.Installed)
+            {
+                if (state == WingetPackageState.Missing)
+                {
+                    if (context.DryRun)
+                    {
+                        return ResourceState.Changed;
+                    }
+
+                    // Install package
+                    state = await InstallPackage(resource.Package).ConfigureAwait(false);
+                    if (state == WingetPackageState.Exists)
+                    {
+                        _logger.Information($"The Winget package [yellow]{resource.Package}[/] was installed");
+                        _refresher.Refresh();
+                        return ResourceState.Changed;
+                    }
+
+                    return ResourceState.Error;
+                }
+
+                _logger.Debug($"The Winget package [yellow]{resource.Package}[/] is already installed");
+            }
+            else
+            {
+                if (state == WingetPackageState.Exists)
+                {
+                    if (context.DryRun)
+                    {
+                        return ResourceState.Changed;
+                    }
+
+                    // Uninstall package
+                    state = await UninstallPackage(resource.Package).ConfigureAwait(false);
+                    if (state == WingetPackageState.Missing)
+                    {
+                        _logger.Information($"The Winget package [yellow]{resource.Package}[/] was uninstalled");
+                        _refresher.Refresh();
+
+                        return ResourceState.Changed;
+                    }
+
+                    return ResourceState.Error;
+                }
+
+                _logger.Debug($"The Winget package [yellow]{resource.Package}[/] is already uninstalled");
+            }
+
+            return ResourceState.Unchanged;
+        }
+
+        private async Task<WingetPackageState> IsPackageInstalled(string package)
+        {
+            if (_dirty || _cachedOutput == null)
+            {
+                var result = await _runner.Run("winget", $"list --source winget --id {package}").ConfigureAwait(false);
+                if (result.ExitCode != 0 && (!result.StandardOut?.EndsWith("No installed package found matching input criteria.") ?? true))
+                {
+                    return WingetPackageState.Error;
+                }
+
+                _cachedOutput = result.StandardOut;
+                _dirty = false;
+            }
+
+            if (_cachedOutput == null)
+            {
+                _logger.Error("An error occured while retrieving Winget state");
+                return WingetPackageState.Error;
+            }
+
+            if (_cachedOutput.Contains(package, StringComparison.OrdinalIgnoreCase))
+            {
+                return WingetPackageState.Exists;
+            }
+
+            return WingetPackageState.Missing;
+        }
+
+        private async Task<WingetPackageState> InstallPackage(string package)
+        {
+            _logger.Debug($"Installing Winget package [yellow]{package}[/]");
+
+            var result = await _runner.Run("winget", $"install -e --id {package} --force").ConfigureAwait(false);
+            if (result.ExitCode != 0)
+            {
+                return WingetPackageState.Error;
+            }
+
+            _dirty = true;
+            return await IsPackageInstalled(package).ConfigureAwait(false);
+        }
+
+        private async Task<WingetPackageState> UninstallPackage(string package)
+        {
+            _logger.Debug($"Uninstalling Winget package {package}...");
+
+            var result = await _runner.Run("winget", $"uninstall -e --id {package}").ConfigureAwait(false);
+            if (result.ExitCode != 0)
+            {
+                return WingetPackageState.Error;
+            }
+
+            _dirty = true;
+            return await IsPackageInstalled(package).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Sandbox/Manifests/WingetPackages.cs
+++ b/src/Sandbox/Manifests/WingetPackages.cs
@@ -1,0 +1,16 @@
+using Cupboard;
+
+namespace Sandbox
+{
+    public sealed class WingetPackages : Manifest
+    {
+        public override void Execute(ManifestContext context)
+        {
+            foreach (var package in new[] { "GitHub.cli" })
+            {
+                context.Resource<WingetPackage>(package)
+                    .Ensure(PackageState.Installed);
+            }
+        }
+    }
+}

--- a/src/Sandbox/Program.cs
+++ b/src/Sandbox/Program.cs
@@ -19,6 +19,7 @@ namespace Sandbox
         {
             context.UseManifest<Chocolatey>();
             context.UseManifest<ChocolateyPackages>();
+            context.UseManifest<WingetPackages>();
         }
     }
 }


### PR DESCRIPTION
Installing winget packages (via resource) as an option for cupboard.

Documentation - https://docs.microsoft.com/en-us/windows/package-manager/

Implementation Detail:
Winget list will report any installed application on the computer and `winget list -s winget` has a bug where it doesn't filter to only packages with known winget packages. Code will query the tool with the desired package name to filter out noise, otherwise you might get false positives (example: specify "code" and it would accidently match "Visual Studio Code").