### PR TITLE
Fix teeny-tiny typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ public sealed class MyWindowsComputer : Catalog
 {
     public override void Execute(CatalogContext context)
     {
-        if (context.Facts.IsWindows())
+        if (!context.Facts.IsWindows())
         {
             return;
         }


### PR DESCRIPTION
You wanna return only if it is NOT Windows.