### PR TITLE
do not cache PackageInstallerProvider when GetPackageState ask for single package state

### DIFF
--- a/src/Cupboard.Providers/VSCode/VSCodeExtensionProvider.cs
+++ b/src/Cupboard.Providers/VSCode/VSCodeExtensionProvider.cs
@@ -9,6 +9,7 @@ namespace Cupboard
         private readonly IProcessRunner _runner;
         private readonly ICupboardEnvironment _environment;
 
+        protected override bool ShouldCache { get; } = true;
         protected override string Name { get; } = "VSCode";
         protected override string Kind { get; } = "extension";
 


### PR DESCRIPTION
closes #38 

see chocolatey or winget GetPackageState

https://github.com/patriksvensson/cupboard/blob/e78c91af009089a331243010e7903689db17f028/src/Cupboard.Providers.Windows/Winget/WingetPackageProvider.cs#L34-L38

https://github.com/patriksvensson/cupboard/blob/e78c91af009089a331243010e7903689db17f028/src/Cupboard.Providers.Windows/Chocolatey/ChocolateyPackageProvider.cs#L63-L67

This is my attempt at keeping the cache for vscode extension.

Potentially we could have a dictionary and instruct the vscode to use the `all` for the same key