### PR TITLE
fix chocolatey provider correctly handle no newline

### DIFF
--- a/src/Cupboard.Providers.Windows/Chocolatey/ChocolateyPackageProvider.cs
+++ b/src/Cupboard.Providers.Windows/Chocolatey/ChocolateyPackageProvider.cs
@@ -47,11 +47,13 @@ namespace Cupboard
             }
 
             var indexOfPipePlusOne = indexOfPipe + 1;
-            var indexOfNewLine = outputSpan[indexOfPipePlusOne..].IndexOfAny('\r', '\n');
-            var versionSpan = indexOfNewLine == -1 ?
-                outputSpan[indexOfPipePlusOne..] :
-                outputSpan.Slice(indexOfPipePlusOne, indexOfNewLine);
+            var indexOfNewLine = outputSpan.IndexOfAny('\r', '\n');
+            if (indexOfNewLine == -1)
+            {
+                indexOfNewLine = outputSpan.Length;
+            }
 
+            var versionSpan = outputSpan[indexOfPipePlusOne..indexOfNewLine];
             return Version.TryParse(versionSpan, out var currentPackageVersion)
                    && Version.TryParse(resource.PackageVersion.AsSpan(), out var packageVersion)
                    && ((resource.AllowDowngrade is true && currentPackageVersion == packageVersion)

--- a/src/Cupboard.Providers.Windows/Chocolatey/ChocolateyPackageProvider.cs
+++ b/src/Cupboard.Providers.Windows/Chocolatey/ChocolateyPackageProvider.cs
@@ -48,12 +48,10 @@ namespace Cupboard
 
             var indexOfPipePlusOne = indexOfPipe + 1;
             var indexOfNewLine = outputSpan[indexOfPipePlusOne..].IndexOfAny('\r', '\n');
-            if (indexOfNewLine == -1)
-            {
-                return false;
-            }
+            var versionSpan = indexOfNewLine == -1 ?
+                outputSpan[indexOfPipePlusOne..] :
+                outputSpan.Slice(indexOfPipePlusOne, indexOfNewLine);
 
-            var versionSpan = outputSpan.Slice(indexOfPipePlusOne, indexOfNewLine);
             return Version.TryParse(versionSpan, out var currentPackageVersion)
                    && Version.TryParse(resource.PackageVersion.AsSpan(), out var packageVersion)
                    && ((resource.AllowDowngrade is true && currentPackageVersion == packageVersion)

--- a/src/Cupboard.Tests/Unit/Providers/ChocolateyProviderTests.cs
+++ b/src/Cupboard.Tests/Unit/Providers/ChocolateyProviderTests.cs
@@ -148,6 +148,31 @@ namespace Cupboard.Tests.Unit.Providers
             }
 
             [WindowsFact]
+            public void Should_Install_Package_If_Lower_Version_With_No_NewLine()
+            {
+                // Given
+                var fixture = new CupboardFixture();
+                fixture.Security.IsAdmin = true;
+                fixture.Process.RegisterDefaultResult(new ProcessRunnerResult(0));
+                fixture.Configure(ctx => ctx.UseManifest<Manifests.InstallVersion>());
+
+                fixture.Process.Register("choco", "list --limit-output --local-only --exact vscode",
+                    new ProcessRunnerResult(0, "vscode|1.57.0"),
+                    new ProcessRunnerResult(0, "vscode|1.58.0"));
+
+                fixture.Process.Register("choco", "install vscode -y --version 1.58.0",
+                    new ProcessRunnerResult(0, "Lol installed VSCode"));
+
+                // When
+                var result = fixture.Run("-y");
+
+                // Then
+                result.Report.GetState<ChocolateyPackage>("Visual Studio Code").ShouldBe(ResourceState.Changed);
+                fixture.Logger.WasLogged("Installing Chocolatey package [yellow]vscode[/]");
+                fixture.Logger.WasLogged("The Chocolatey package [yellow]vscode[/] was installed");
+            }
+
+            [WindowsFact]
             public void Should_Not_Install_Package_Of_Same_Version()
             {
                 // Given


### PR DESCRIPTION
seems like chocolatey now outputting newlines when listing --exact